### PR TITLE
Fixing edit and issues link in docs. 

### DIFF
--- a/docs/theme.config.jsx
+++ b/docs/theme.config.jsx
@@ -44,4 +44,6 @@ export default {
       </span>
     ),
   },
+  docsRepositoryBase:
+    'https://github.com/mustafaaljadery/mlx-server/blob/main/docs'
 };


### PR DESCRIPTION
Updating link to repository so that the edit and new issues link work.

Currently the links in the right sidebar still lead to the nextra repository:
![CleanShot 2024-03-15 at 08 03 08](https://github.com/mustafaaljadery/mlxserver/assets/4542479/f237d06c-2f9a-4400-bcb0-72b855464472)

I've changed it so it now points to the right one. The reason I noticed was that now macOs 13.5 is needed and I wanted to fix the docs. :) #3 